### PR TITLE
Allowing demos to run properly in windows

### DIFF
--- a/config/webpack/webpack.demo-visual.js
+++ b/config/webpack/webpack.demo-visual.js
@@ -14,7 +14,7 @@ var entry = {};
     var parts;
 
     dirname = path.dirname(file);
-    parts = dirname.split(path.sep);
+    parts = dirname.split('/'); // glob always returns '/' as separator
     demoName = parts[parts.length - 2];
     entry[demoName] = file;
 

--- a/config/webpack/webpack.demo.js
+++ b/config/webpack/webpack.demo.js
@@ -14,7 +14,7 @@ var entry = {};
     var parts;
 
     dirname = path.dirname(file);
-    parts = dirname.split(path.sep);
+    parts = dirname.split('/'); // glob always returns '/' as separator
     demoName = parts[parts.length - 1];
 
     entry[demoName] = './demo/src/' + demoName + '/app.component.ts';


### PR DESCRIPTION
Fixes #146 

`glob` always returns `/` as path separator, regardless of architecture, so we need to split on `/` instead of `path.sep`.