### PR TITLE
Only run unit tests in modules

### DIFF
--- a/config/utils/spec-bundle.js
+++ b/config/utils/spec-bundle.js
@@ -51,7 +51,7 @@ Object.assign(global, testing);
  * any file that ends with spec.js and get its path. By passing in true
  * we say do this recursively
  */
-var testContext = require.context('../../src', true, /\.spec\.ts/);
+var testContext = require.context('../../src/modules', true, /\.spec\.ts/);
 
 /*
  * get all the files, for each file, call the context function


### PR DESCRIPTION
This keeps SKY Pages unit tests from running during a SKY UX 2 test run.