### PR TITLE
Only commiting back NEW files from visual tests

### DIFF
--- a/scripts/visual-baseline.sh
+++ b/scripts/visual-baseline.sh
@@ -14,7 +14,7 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && ! $TRAVIS_BRANCH =~ $SAVAGE_BRANCH ]]
 
   git add webdriver-screenshots/
 
-  if [ -z "$(git status --porcelain)" ]; then
+  if [ -z "$(git ls-files --others --exclude-standard)" ]; then
     echo -e "No changes to commit to skyux2."
   else
     git commit -m "Travis build $TRAVIS_BUILD_NUMBER pushed to skyux2 [ci skip]"


### PR DESCRIPTION
In debugging failed releases, we realized that image changes were small enough to pass our visual threshold, but still slightly different.  Git sees this as a changed file.  Our logic only tested for changed files, so they were committed back on pushes/merges to master.

This change instead only looks for NEW files, versus modified files.  In the future, we'll continue to delete screenshots if they need to be updated, thereby causing this logic to kick in where they're committed back.