### PR TITLE
Add aria-selected="true|false" to tab the A tags that have role="tab".

### DIFF
--- a/src/modules/tabs/tab-button.component.html
+++ b/src/modules/tabs/tab-button.component.html
@@ -7,6 +7,7 @@
     }"
     (click)="doTabClick()"
     role="tab"
+    [attr.aria-selected]="active"
 >
   {{tabHeading}}
   <button

--- a/src/modules/tabs/tabset.component.spec.ts
+++ b/src/modules/tabs/tabset.component.spec.ts
@@ -25,8 +25,9 @@ describe('Tabset component', () => {
   function validateTabSelected(el: Element, tabIndex: number) {
     let selectedCls: string;
     let buttonEls: NodeListOf<Element>;
+    let inDropDownMode = el.querySelector('.sky-tabset-mode-dropdown');
 
-    if (el.querySelector('.sky-tabset-mode-dropdown')) {
+    if (inDropDownMode) {
       selectedCls = 'sky-tab-dropdown-item-selected';
       buttonEls = el.querySelectorAll('.sky-tab-dropdown-item');
     } else {
@@ -52,6 +53,10 @@ describe('Tabset component', () => {
 
       expect(buttonEl.classList.contains(selectedCls)).toBe(expectedHasClass);
       expect(panelDisplay).toBe(expectedDisplay);
+
+      if (!inDropDownMode) {
+        expect(buttonEl.getAttribute('aria-selected')).toBe(expectedHasClass.toString());
+      }
     }
   }
 


### PR DESCRIPTION
I wanted to pick up #188 and found some missing ARIA attributes as recommended by [WAI-ARIA Authoring Practices 1.1 (Draft 14 December 2016)](https://www.w3.org/TR/wai-aria-practices-1.1). 
