### PR TITLE
Add "menu" and "menuitem" roles and "aria-haspopup" attribute.

### DIFF
--- a/src/modules/dropdown/dropdown-item.component.spec.ts
+++ b/src/modules/dropdown/dropdown-item.component.spec.ts
@@ -1,0 +1,31 @@
+import {
+  TestBed
+} from '@angular/core/testing';
+
+import { DropdownTestComponent } from './fixtures/dropdown.component.fixture';
+import { SkyDropdownFixturesModule } from './fixtures/dropdown-fixtures.module';
+
+import { expect } from '../testing';
+
+describe('Dropdown menu item component', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          SkyDropdownFixturesModule
+        ]
+      });
+    });
+
+    function getMenuItem(el: Element) {
+      return <HTMLElement>el.querySelector('sky-dropdown-item');
+    }
+
+    it('should have a role of type "menuitem"', () => {
+      let fixture = TestBed.createComponent(DropdownTestComponent);
+      let el: Element = fixture.nativeElement;
+
+      fixture.detectChanges();
+
+      expect(getMenuItem(el).getAttribute('role')).toBe('menuitem');
+    });
+});

--- a/src/modules/dropdown/dropdown-item.component.ts
+++ b/src/modules/dropdown/dropdown-item.component.ts
@@ -1,8 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, OnInit } from '@angular/core';
 
 @Component({
   selector: 'sky-dropdown-item',
   templateUrl: './dropdown-item.component.html',
   styleUrls: ['./dropdown-item.component.scss']
 })
-export class SkyDropdownItemComponent { }
+export class SkyDropdownItemComponent implements OnInit {
+  constructor(private el: ElementRef) {}
+
+  public ngOnInit() {
+    this.el.nativeElement.setAttribute('role', 'menuitem');
+  }
+}

--- a/src/modules/dropdown/dropdown-menu.component.spec.ts
+++ b/src/modules/dropdown/dropdown-menu.component.spec.ts
@@ -1,0 +1,31 @@
+import {
+  TestBed
+} from '@angular/core/testing';
+
+import { DropdownTestComponent } from './fixtures/dropdown.component.fixture';
+import { SkyDropdownFixturesModule } from './fixtures/dropdown-fixtures.module';
+
+import { expect } from '../testing';
+
+describe('Dropdown menu component', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          SkyDropdownFixturesModule
+        ]
+      });
+    });
+
+    function getMenu(el: Element) {
+      return <HTMLElement>el.querySelector('sky-dropdown-menu');
+    }
+
+    it('should have a role of type "menu"', () => {
+      let fixture = TestBed.createComponent(DropdownTestComponent);
+      let el: Element = fixture.nativeElement;
+
+      fixture.detectChanges();
+
+      expect(getMenu(el).getAttribute('role')).toBe('menu');
+    });
+});

--- a/src/modules/dropdown/dropdown-menu.component.ts
+++ b/src/modules/dropdown/dropdown-menu.component.ts
@@ -1,8 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, OnInit } from '@angular/core';
 
 @Component({
   selector: 'sky-dropdown-menu',
   templateUrl: '../shared/simple-content.html',
   styleUrls: ['./dropdown-menu.component.scss']
 })
-export class SkyDropdownMenuComponent { }
+export class SkyDropdownMenuComponent implements OnInit {
+  constructor(private el: ElementRef) {}
+
+  public ngOnInit() {
+    this.el.nativeElement.setAttribute('role', 'menu');
+  }
+}

--- a/src/modules/dropdown/dropdown.component.html
+++ b/src/modules/dropdown/dropdown.component.html
@@ -6,6 +6,7 @@
       [ngClass]="'sky-dropdown-button-type-' + buttonType"
       (document:click)="windowClick()"
       [attr.aria-label]="label"
+      aria-haspopup="true"
   >
     <div [ngSwitch]="buttonType">
       <template ngSwitchCase="context-menu">

--- a/src/modules/dropdown/dropdown.component.spec.ts
+++ b/src/modules/dropdown/dropdown.component.spec.ts
@@ -38,6 +38,15 @@ describe('Dropdown component', () => {
       expect(getDropdownBtnEl(el)).toHaveCssClass('sky-dropdown-button-type-select');
     });
 
+    it('should have an aria-haspopup role on the button', () => {
+      let fixture = TestBed.createComponent(DropdownTestComponent);
+      let el: Element = fixture.nativeElement;
+
+      fixture.detectChanges();
+
+      expect(getDropdownBtnEl(el).getAttribute('aria-haspopup')).toBe('true');
+    });
+
     it('should set the correct button type CSS class', () => {
       let fixture = TestBed.createComponent(DropdownTestComponent);
       let cmp = fixture.componentInstance;


### PR DESCRIPTION
Add "menu" and "menuitem" roles to sky-dropdown-menu and sky-dropdown-item, respectively. Add "aria-haspopup" with a value of "true" to sky-dropdown .sky-dropdown-button.

I wanted to pick up #188 and found some missing ARIA attributes as recommended by [WAI-ARIA Authoring Practices 1.1 (Draft 14 December 2016)](https://www.w3.org/TR/wai-aria-practices-1.1). 
