### PR TITLE
Alert component to have role="alert" and more description on the close button.

### DIFF
--- a/src/locales/resources_en_US.json
+++ b/src/locales/resources_en_US.json
@@ -5,7 +5,7 @@
     },
     "alert_close": {
         "_description": "Screen reader text for the close button on alerts",
-        "message": "Close"
+        "message": "Close the alert"
     },
     "autonumeric_abbr_billions": {
         "_description": "The suffix to show after an abbreviated value in the billions (e.g. $1.2b)",

--- a/src/modules/alert/alert.component.html
+++ b/src/modules/alert/alert.component.html
@@ -8,6 +8,7 @@
       'sky-alert-closeable': closeable
     }"
     [hidden]="closed"
+    role="alert"
 >
   <ng-content></ng-content>
   <button

--- a/src/modules/alert/alert.component.spec.ts
+++ b/src/modules/alert/alert.component.spec.ts
@@ -98,4 +98,18 @@ describe('Alert component', () => {
 
     expect(alertEl.classList.contains('sky-alert-warning')).toBe(true);
   });
+
+  it('should have a role of "alert"', () => {
+    let fixture = TestBed.createComponent(AlertTestComponent);
+    let cmp = fixture.componentInstance as AlertTestComponent;
+    let el = fixture.nativeElement as HTMLElement;
+
+    cmp.alertType = undefined;
+
+    fixture.detectChanges();
+
+    let alertEl = el.querySelector('.sky-alert');
+
+    expect(alertEl.getAttribute('role')).toBe('alert');
+  });
 });


### PR DESCRIPTION
I wanted to pick up #188 and found some missing ARIA attributes as recommended by [WAI-ARIA Authoring Practices 1.1 (Draft 14 December 2016)](https://www.w3.org/TR/wai-aria-practices-1.1). 
