### PR TITLE
Documentation tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,4 +4,4 @@
 
 ### Steps to reproduce
 
-### Plunker (see example SKY UX 2 plunker template at: http://plnkr.co/edit/9446PP1PspjD4R1aVZys?p=preview)
+### Plunker (see example SKY UX 2 plunker template at: https://plnkr.co/edit/GeP22YbirEzceF3NVu39?p=preview)

--- a/src/app/components/demo-components.service.ts
+++ b/src/app/components/demo-components.service.ts
@@ -264,7 +264,8 @@ export class SkyDemoComponentsService {
             },
             {
               name: 'modal-demo-form.component.ts',
-              fileContents: require('!!raw!./modal/modal-demo-form.component.ts')
+              fileContents: require('!!raw!./modal/modal-demo-form.component.ts'),
+              componentName: 'SkyModalDemoFormComponent'
             },
             {
               name: 'modal-demo-context.ts',
@@ -443,7 +444,8 @@ export class SkyDemoComponentsService {
             },
             {
               name: 'tiles-demo-tile1.component.ts',
-              fileContents: require('!!raw!./tiles/tiles-demo-tile1.component.ts')
+              fileContents: require('!!raw!./tiles/tiles-demo-tile1.component.ts'),
+              componentName: 'SkyTilesDemoTile1Component'
             },
             {
               name: 'tiles-demo-tile2.component.html',

--- a/src/app/components/shared/demo-page-code-file.ts
+++ b/src/app/components/shared/demo-page-code-file.ts
@@ -7,6 +7,8 @@ export class SkyDemoPageCodeFile {
 
   public codeFormatted: string;
 
+  public codeImports: string;
+
   constructor(
     public readonly name: string,
     public readonly code: string,
@@ -22,9 +24,10 @@ export class SkyDemoPageCodeFile {
       default:
         this.language = 'markup';
     }
+    this.codeImports = this.code.replace(/\.\.\/\.\.\/\.\.\/core/g, '@blackbaud/skyux/dist/core');
 
     this.codeFormatted = Prism.highlight(
-      this.code,
+      this.codeImports,
       Prism.languages[this.language]
     );
   }

--- a/src/app/components/shared/demo-page-plunker-service.ts
+++ b/src/app/components/shared/demo-page-plunker-service.ts
@@ -16,7 +16,7 @@ export class SkyDemoPagePlunkerService {
     for (let codeFile of codeFiles) {
       files.push({
         name: codeFile.name,
-        content: codeFile.code
+        content: codeFile.codeImports
       });
 
       let componentName = codeFile.componentName;
@@ -67,7 +67,11 @@ export class SkyDemoPagePlunkerService {
 
     'rxjs': 'npm:rxjs',
     'typescript': 'npm:typescript@2.0.2/lib/typescript.js',
-    'skyux/core': 'npm:blackbaud-skyux2/dist/bundles/core.umd.min.js',
+    '@blackbaud/skyux/dist/core': 'npm:@blackbaud/skyux/dist/bundles/core.umd.min.js',
+
+    'moment': 'npm:moment/moment.js',
+
+    'microedge-rxstate/dist': 'npm:microedge-rxstate/dist/index.js',
 
     //dragula packages
     'ng2-dragula/ng2-dragula': 'npm:ng2-dragula',
@@ -87,7 +91,7 @@ export class SkyDemoPagePlunkerService {
     rxjs: {
       defaultExtension: 'js'
     },
-    'skyux/core': {
+    '@blackbaud/skyux/dist/core': {
        format: 'cjs'
      },
     'ng2-dragula/ng2-dragula': {
@@ -157,7 +161,7 @@ export class AppComponent() { }`
 import { Component, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
-import { SkyModule } from 'skyux/core';
+import { SkyModule } from '@blackbaud/skyux/dist/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 ${imports.join('\n')}

--- a/src/app/components/tiles/index.html
+++ b/src/app/components/tiles/index.html
@@ -1,7 +1,7 @@
 <sky-demo-page title="Tiles">
   <sky-demo-page-summary>
     <p>
-      The <code>sky-tile</code> directive creates a collapsible container and is the bulding block for pages and forms in a SKY UX application. The <code>sky-tile-section</code> directive is used to create padded sections inside a <code>sky-tile</code> element. Additionally, the <code>sky-tile-summary</code> directive may be placed inside the <code>sky-tile</code> directive to add summary information to the tile.
+      The <code>sky-tile</code> directive creates a collapsible container and is the bulding block for pages and forms in a SKY UX application. The <code>sky-tile-section</code> directive is used to create padded sections inside a <code>sky-tile</code> element. Additionally, the <code>sky-tile-summary</code> directive may be placed inside the <code>sky-tile</code> directive to add summary information to the tile. Any <code>sky-tile</code> components used within a <code>sky-tile-dashboard</code> must be included as entry components in the application module.
     </p>
   </sky-demo-page-summary>
 


### PR DESCRIPTION
- Plunker fixes for modals and tiles
- In the code example section of the documentation show importing from
the npm package path
- Plunkers use latest package instead of old alpha package
- Update tile documentation to mention using entry components with tile
dashboard.
- Update issue template to use new plunker template