### PR TITLE
Key info text is too large #537

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -52,7 +52,7 @@
 }
 
 @mixin sky-field-label {
-  font: 400 $sky-font-size-base $sky-font-family-base;
+  font: 400 $sky-font-size-base $sky-alternate-font-size-lg; // ~24px;
   color: $sky-text-deemphasized-color;
 }
 


### PR DESCRIPTION
base=22 lg=24px

Key info text : .sky-key-info-label
@mixin sky-field-label
sky-alternate-font-size-base // ~22px