### PR TITLE
Added sanity checks for unsubscribes of subscriptions on ngOnDestroys

### DIFF
--- a/src/app/components/media-queries/media-query-demo.component.ts
+++ b/src/app/components/media-queries/media-query-demo.component.ts
@@ -41,6 +41,10 @@ export class SkyMediaQueryDemoComponent implements OnDestroy {
   }
 
   public ngOnDestroy() {
-    this.querySubscription.unsubscribe();
+    /* istanbul ignore else */
+    /* sanity check */
+    if (this.querySubscription) {
+      this.querySubscription.unsubscribe();
+    }
   }
 }

--- a/src/modules/action-button/action-button-icon.component.ts
+++ b/src/modules/action-button/action-button-icon.component.ts
@@ -41,6 +41,10 @@ export class SkyActionButtonIconComponent implements OnDestroy {
   }
 
   public ngOnDestroy() {
-    this.subscription.unsubscribe();
+    /* istanbul ignore else */
+    /* sanity check */
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 }

--- a/src/modules/page-summary/page-summary.component.ts
+++ b/src/modules/page-summary/page-summary.component.ts
@@ -28,6 +28,10 @@ export class SkyPageSummaryComponent implements OnDestroy, AfterViewInit {
   }
 
   public ngOnDestroy() {
-    this.breakpointSubscription.unsubscribe();
+    /* istanbul ignore else */
+    /* sanity check */
+    if (this.breakpointSubscription) {
+      this.breakpointSubscription.unsubscribe();
+    }
   }
 }


### PR DESCRIPTION
This will be useful for testing purposes if these components are child components of other things that have unit tests that don't fully initialize all of the view with detectChanges calls. I did a search for these methods and all of these now have these checks. Some were already in place before this work.