### PR TITLE
Changes to ensure that the text expand maxLength property is set correctly

### DIFF
--- a/src/modules/text-expand/fixtures/text-expand.component.fixture.html
+++ b/src/modules/text-expand/fixtures/text-expand.component.fixture.html
@@ -1,1 +1,6 @@
-<sky-text-expand [text]="text"></sky-text-expand>
+<div *ngIf="maxLength">
+  <sky-text-expand [maxLength]="maxLength" [text]="text"></sky-text-expand>
+</div>
+<div *ngIf="!maxLength">
+  <sky-text-expand [text]="text"></sky-text-expand>
+</div>

--- a/src/modules/text-expand/fixtures/text-expand.component.fixture.ts
+++ b/src/modules/text-expand/fixtures/text-expand.component.fixture.ts
@@ -7,4 +7,5 @@ import { Component } from '@angular/core';
 export class TextExpandTestComponent {
   // tslint:disable-next-line
   public text: string;
+  public maxLength: number;
 }

--- a/src/modules/text-expand/text-expand.component.spec.ts
+++ b/src/modules/text-expand/text-expand.component.spec.ts
@@ -65,6 +65,24 @@ describe('Text expand component', () => {
       expect(seeMoreButton).toBeNull();
     });
 
+    // tslint:disable-next-line
+    it('should not have see more button or ellipsis if text is long but less than the set max length', () => {
+      let fixture = TestBed.createComponent(TextExpandTestComponent);
+      let cmp = fixture.componentInstance as TextExpandTestComponent;
+      let el = fixture.nativeElement as HTMLElement;
+
+      // tslint:disable-next-line
+      cmp.text = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec foo bar.';
+      cmp.maxLength = 400;
+
+      fixture.detectChanges();
+
+      let ellipsis: any = el.querySelector('.sky-text-expand-ellipsis');
+      let seeMoreButton: any = el.querySelector('.sky-text-expand-see-more');
+      expect(ellipsis).toBeNull();
+      expect(seeMoreButton).toBeNull();
+    });
+
     it('should have the see more button and ellipsis if text is longer', () => {
       let fixture = TestBed.createComponent(TextExpandTestComponent);
       let cmp = fixture.componentInstance as TextExpandTestComponent;

--- a/src/modules/text-expand/text-expand.component.ts
+++ b/src/modules/text-expand/text-expand.component.ts
@@ -110,9 +110,7 @@ export class SkyTextExpandComponent implements AfterContentInit {
     if (value) {
       this.newlineCount = this.getNewlineCount(value);
       this.collapsedText = this.getTruncatedText(value, this.maxLength, this.maxNewlines);
-      this.expandedText = value.length > this.maxExpandedLength ||
-        this.newlineCount > this.maxExpandedNewlines ?
-        value : this.getTruncatedText(value, this.maxExpandedLength, this.maxExpandedNewlines);
+      this.expandedText = value;
       if (this.collapsedText !== value) {
         this.buttonText = this.seeMoreText;
         this.isExpanded = false;

--- a/src/modules/text-expand/text-expand.component.ts
+++ b/src/modules/text-expand/text-expand.component.ts
@@ -2,7 +2,8 @@ import {
   Component,
   Input,
   ElementRef,
-  ViewChild
+  ViewChild,
+  AfterContentInit
 } from '@angular/core';
 
 import {
@@ -29,7 +30,7 @@ import {
     SkyResourcesService
   ]
 })
-export class SkyTextExpandComponent {
+export class SkyTextExpandComponent implements AfterContentInit {
   @Input()
   public set text(value: string) {
     this.setup(value);
@@ -42,10 +43,6 @@ export class SkyTextExpandComponent {
   public maxExpandedNewlines: number = 2;
   @Input()
   public expandModalTitle: string = this.resources.getString('text_expand_modal_title');
-  @Input()
-  public expandRepeaterMax: number;
-  @Input()
-  public expandRepeaterData: number;
   @ViewChild('container')
   public containerEl: ElementRef;
   @ViewChild('text')
@@ -103,6 +100,10 @@ export class SkyTextExpandComponent {
     this.textExpandAdapter.setText(this.textEl, this.textToShow);
     // Set height back to auto so the browser can change the height as needed with window changes
     this.textExpandAdapter.setContainerHeight(this.containerEl, 'auto');
+  }
+
+  public ngAfterContentInit() {
+    this.setup(this.expandedText);
   }
 
   private setup(value: string) {


### PR DESCRIPTION
#617 
This adds a lifecycle hook after the inputs are all set to reevaluate the collapsed text. It appears that the "setup" call was happening before the maxLength property was set and so it was using the default value of 200. If the text was changed later it used the correct value.