### PR TITLE
Fixing navbar alignment in IE11

### DIFF
--- a/src/modules/navbar/navbar-item.component.scss
+++ b/src/modules/navbar/navbar-item.component.scss
@@ -1,9 +1,10 @@
 @import '../../scss/mixins';
 
 .sky-navbar-item {
-  display: inline-block;
+  display: block;
   font-weight: 600;
   margin-right: $sky-margin-half;
+  float: left;
 
   /deep/ {
     a,

--- a/src/modules/navbar/navbar-item.component.scss
+++ b/src/modules/navbar/navbar-item.component.scss
@@ -1,10 +1,16 @@
 @import '../../scss/mixins';
 
+:host {
+  display: block;
+  float: left;
+  overflow: hidden;
+}
+
 .sky-navbar-item {
   display: block;
   font-weight: 600;
   margin-right: $sky-margin-half;
-  float: left;
+  height: 100%;
 
   /deep/ {
     a,
@@ -12,7 +18,7 @@
       background-color: transparent;
       border: none;
       color: $sky-nav-color;
-      display: inline-block;
+      display: block;
       padding: 16px 12px;
       text-decoration: none;
       width: 100%;
@@ -41,7 +47,6 @@
     }
   }
 
-  /deep/ > *:hover,
   /deep/ .sky-dropdown:hover .sky-dropdown-button,
   /deep/ .sky-navbar-item-active,
   &.sky-navbar-item-active /deep/ > *,

--- a/src/modules/navbar/navbar-item.component.scss
+++ b/src/modules/navbar/navbar-item.component.scss
@@ -1,11 +1,5 @@
 @import '../../scss/mixins';
 
-:host {
-  display: block;
-  float: left;
-  overflow: hidden;
-}
-
 .sky-navbar-item {
   display: block;
   font-weight: 600;

--- a/src/modules/navbar/navbar.component.scss
+++ b/src/modules/navbar/navbar.component.scss
@@ -2,10 +2,7 @@
 
 .sky-navbar {
   background-color: $sky-nav-background-color;
-
-  &:after {
-    content: '';
-    display: table;
-    width: 100%;
-  }
+  display: flex;
+  align-items: flex-start;
+  flex-direction: row;
 }

--- a/src/modules/navbar/navbar.component.scss
+++ b/src/modules/navbar/navbar.component.scss
@@ -2,4 +2,10 @@
 
 .sky-navbar {
   background-color: $sky-nav-background-color;
+
+  &:after {
+    content: '';
+    display: table;
+    clear: both;
+  }
 }

--- a/src/modules/navbar/navbar.component.scss
+++ b/src/modules/navbar/navbar.component.scss
@@ -6,6 +6,6 @@
   &:after {
     content: '';
     display: table;
-    clear: both;
+    width: 100%;
   }
 }


### PR DESCRIPTION
Dropdown components are not aligned properly in IE11 on the navbar. There is an IE11 problem with flex elements as children to inline-block elements. This fix uses flex to lay out the nav bar items instead of using inline-block. #853 