### PR TITLE
Allow for correct text-overflow on list view checklists

### DIFF
--- a/src/modules/list-view-checklist/list-view-checklist-item.component.scss
+++ b/src/modules/list-view-checklist/list-view-checklist-item.component.scss
@@ -22,10 +22,15 @@
     flex: 1;
     position: relative;
     overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
     cursor: pointer;
     padding-left: $sky-padding;
+
+    div {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
   }
 
   /deep/ .sky-list-view-checklist-single-button {

--- a/src/modules/list-view-checklist/list-view-checklist.component.html
+++ b/src/modules/list-view-checklist/list-view-checklist.component.html
@@ -29,8 +29,12 @@
             [checked]="itemSelected(item.id) | async"
             (change)="setItemSelection(item, $event)">
             <sky-checkbox-label>
-              <div class="sky-emphasized" *ngIf="item.label">{{item.label}}</div>
-              <div *ngIf="item.description">{{item.description}}</div>
+              <div class="sky-emphasized" *ngIf="item.label" [attr.title]="item.label">
+                {{item.label}}
+              </div>
+              <div *ngIf="item.description" [attr.title]="item.description">
+                {{item.description}}
+              </div>
             </sky-checkbox-label>
           </sky-checkbox>
         </sky-list-view-checklist-item>


### PR DESCRIPTION
#1000 

This was being caused by the text-overflow and overflow css properties not getting applied to the `div` elements inside the list view checklists. The css was present but not specific enough for it to cascade down to the `div` elements and apply. This fix should remedy that. 