### PR TITLE
Fixed all references to `Element.matches` (Edge & IE11)

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1,5 +1,13 @@
 import { NgModule } from '@angular/core';
 
+// Element matches polyfill
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
+if (!Element.prototype.matches) {
+  Element.prototype.matches =
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.webkitMatchesSelector;
+}
+
 import { SKY_MODAL_PROVIDERS } from './modules/modal';
 import { SKY_WAIT_PROVIDERS } from './modules/wait';
 


### PR DESCRIPTION
Addresses https://github.com/blackbaud/skyux2/issues/1133, as well as List View Grid draggable columns (no issue filed). 

There may be other instances of the `.matches` method that were not reported, so this polyfill will cover those as well.