### PR TITLE
Fixed file attachments component in IE11

### DIFF
--- a/src/modules/fileattachments/file-drop.component.spec.ts
+++ b/src/modules/fileattachments/file-drop.component.spec.ts
@@ -644,8 +644,6 @@ describe('File drop component', () => {
     componentInstance.filesChanged.subscribe(
       (filesChanged: SkyFileDropChange) => filesChangedActual = filesChanged );
 
-    let fileReaderSpy = setupFileReaderSpy();
-
     componentInstance.acceptedTypes = 'image/png, image/tiff';
 
     fixture.detectChanges();

--- a/src/modules/fileattachments/file-drop.component.spec.ts
+++ b/src/modules/fileattachments/file-drop.component.spec.ts
@@ -199,10 +199,10 @@ describe('File drop component', () => {
 
     if (fileReaderSpy.loadCallbacks[0]) {
        fileReaderSpy.loadCallbacks[0]({
-          target: {
-            result: 'url'
-          }
-        });
+        target: {
+          result: 'url'
+        }
+      });
     }
 
     if (fileReaderSpy.loadCallbacks[1]) {
@@ -363,7 +363,7 @@ describe('File drop component', () => {
 
     componentInstance.validateFn = function(file: any) {
       if (file.file.name.indexOf('w') === 0) {
-          return errorMessage;
+        return errorMessage;
       }
     };
 
@@ -407,7 +407,7 @@ describe('File drop component', () => {
     expect(filesChangedActual.files[0].file.size).toBe(1000);
   });
 
-   it('should reject a file with no type when accepted types are defined', () => {
+  it('should reject a file with no type when accepted types are defined', () => {
     let filesChangedActual: SkyFileDropChange;
 
     componentInstance.filesChanged.subscribe(
@@ -418,16 +418,16 @@ describe('File drop component', () => {
     fixture.detectChanges();
 
     let files = [
-        {
-          name: 'foo.txt',
-          size: 1000
-        },
-        {
-          name: 'woo.txt',
-          size: 2000,
-          type: 'image/jpeg'
-        }
-      ];
+      {
+        name: 'foo.txt',
+        size: 1000
+      },
+      {
+        name: 'woo.txt',
+        size: 2000,
+        type: 'image/jpeg'
+      }
+    ];
 
     setupStandardFileChangeEvent(files);
 
@@ -493,6 +493,7 @@ describe('File drop component', () => {
 
     let dragOverEvent = {
       dataTransfer: {
+        files: {} as any,
         items: files
       },
       stopPropagation: function () {
@@ -516,14 +517,13 @@ describe('File drop component', () => {
 
     let dropEvent = {
       dataTransfer: {
-        files:
-          {
-            length: fileLength,
-            item: function (index: number) {
-              return files[index];
-            }
-          },
-          items: files
+        files: {
+          length: fileLength,
+          item: function (index: number) {
+            return files[index];
+          }
+        },
+        items: files
       },
       stopPropagation: function () {
         dropPropStopped = true;
@@ -564,20 +564,20 @@ describe('File drop component', () => {
     let dropDebugEl = getDropDebugEl();
 
     let files = [
-        {
-          name: 'foo.txt',
-          size: 1000,
-          type: 'image/png'
-        }
-      ];
+      {
+        name: 'foo.txt',
+        size: 1000,
+        type: 'image/png'
+      }
+    ];
 
     let invalidFiles = [
-        {
-          name: 'foo.txt',
-          size: 1000,
-          type: 'image/jpeg'
-        }
-      ];
+      {
+        name: 'foo.txt',
+        size: 1000,
+        type: 'image/jpeg'
+      }
+    ];
 
     triggerDragEnter('sky-drop', dropDebugEl);
     triggerDragOver(files, dropDebugEl);
@@ -588,6 +588,7 @@ describe('File drop component', () => {
     triggerDrop(files, dropDebugEl);
 
     validateDropClasses(false, false, dropElWrapper);
+
     fileReaderSpy.loadCallbacks[0]({
       target: {
         result: 'url'
@@ -597,7 +598,6 @@ describe('File drop component', () => {
     fixture.detectChanges();
 
     expect(filesChangedActual.rejectedFiles.length).toBe(0);
-
     expect(filesChangedActual.files.length).toBe(1);
     expect(filesChangedActual.files[0].url).toBe('url');
     expect(filesChangedActual.files[0].file.name).toBe('foo.txt');
@@ -618,7 +618,7 @@ describe('File drop component', () => {
     validateDropClasses(false, false, dropElWrapper);
 
     let emptyEvent = {
-      stopPropagation: function (){},
+      stopPropagation: function () {},
       preventDefault: function () {}
     };
 
@@ -635,66 +635,101 @@ describe('File drop component', () => {
 
   });
 
+  it([
+    'should accept a file of rejected type on drag (but not on drop)',
+    'if the browser does not support dataTransfer.items'
+  ].join(' '), () => {
+    let filesChangedActual: SkyFileDropChange;
+
+    componentInstance.filesChanged.subscribe(
+      (filesChanged: SkyFileDropChange) => filesChangedActual = filesChanged );
+
+    let fileReaderSpy = setupFileReaderSpy();
+
+    componentInstance.acceptedTypes = 'image/png, image/tiff';
+
+    fixture.detectChanges();
+
+    let dropDebugEl = getDropDebugEl();
+
+    let invalidFiles = [
+      {
+        name: 'foo.txt',
+        size: 1000,
+        type: 'image/jpeg'
+      }
+    ];
+
+    let dropElWrapper = getDropElWrapper();
+
+    triggerDragEnter('sky-drop', dropDebugEl);
+    triggerDragOver(undefined, dropDebugEl);
+    validateDropClasses(true, false, dropElWrapper);
+
+    triggerDrop(invalidFiles, dropDebugEl);
+    validateDropClasses(false, false, dropElWrapper);
+  });
+
   it('should prevent loading multiple files on drag and drop when multiple is false', () => {
     let files = [
-        {
-          name: 'foo.txt',
-          size: 1000,
-          type: 'image/png'
-        },
-        {
-          name: 'goo.txt',
-          size: 1000,
-          type: 'image/png'
-        }
-      ];
+      {
+        name: 'foo.txt',
+        size: 1000,
+        type: 'image/png'
+      },
+      {
+        name: 'goo.txt',
+        size: 1000,
+        type: 'image/png'
+      }
+    ];
 
-      let filesChangedActual: SkyFileDropChange;
+    let filesChangedActual: SkyFileDropChange;
 
-      componentInstance.filesChanged.subscribe(
-        (filesChanged: SkyFileDropChange) => filesChangedActual = filesChanged );
+    componentInstance.filesChanged.subscribe(
+      (filesChanged: SkyFileDropChange) => filesChangedActual = filesChanged );
 
-      let fileReaderSpy = setupFileReaderSpy();
+    let fileReaderSpy = setupFileReaderSpy();
 
-      componentInstance.multiple = false;
-      fixture.detectChanges();
+    componentInstance.multiple = false;
+    fixture.detectChanges();
 
-      let dropDebugEl = getDropDebugEl();
+    let dropDebugEl = getDropDebugEl();
 
-      triggerDragEnter('sky-drop', dropDebugEl);
-      triggerDragOver(files, dropDebugEl);
-      triggerDrop(files, dropDebugEl);
-      expect(fileReaderSpy.loadCallbacks.length).toBe(0);
+    triggerDragEnter('sky-drop', dropDebugEl);
+    triggerDragOver(files, dropDebugEl);
+    triggerDrop(files, dropDebugEl);
+    expect(fileReaderSpy.loadCallbacks.length).toBe(0);
   });
 
   it('should prevent loading directories on drag and drop', () => {
     let files = [
-        {
-          name: 'foo.txt',
-          size: 1000,
-          type: 'image/png',
-          webkitGetAsEntry: function () {
-            return {
-              isDirectory: true
-            };
-          }
+      {
+        name: 'foo.txt',
+        size: 1000,
+        type: 'image/png',
+        webkitGetAsEntry: function () {
+          return {
+            isDirectory: true
+          };
         }
-      ];
+      }
+    ];
 
-      let filesChangedActual: SkyFileDropChange;
+    let filesChangedActual: SkyFileDropChange;
 
-      componentInstance.filesChanged.subscribe(
-        (filesChanged: SkyFileDropChange) => filesChangedActual = filesChanged );
+    componentInstance.filesChanged.subscribe(
+      (filesChanged: SkyFileDropChange) => filesChangedActual = filesChanged );
 
-      let fileReaderSpy = setupFileReaderSpy();
-      fixture.detectChanges();
+    let fileReaderSpy = setupFileReaderSpy();
+    fixture.detectChanges();
 
-      let dropDebugEl = getDropDebugEl();
+    let dropDebugEl = getDropDebugEl();
 
-      triggerDragEnter('sky-drop', dropDebugEl);
-      triggerDragOver(files, dropDebugEl);
-      triggerDrop(files, dropDebugEl);
-      expect(fileReaderSpy.loadCallbacks.length).toBe(0);
+    triggerDragEnter('sky-drop', dropDebugEl);
+    triggerDragOver(files, dropDebugEl);
+    triggerDrop(files, dropDebugEl);
+    expect(fileReaderSpy.loadCallbacks.length).toBe(0);
   });
 
   it('should show link section when allowLinks is true', () => {


### PR DESCRIPTION
Addresses: https://github.com/blackbaud/skyux2/issues/1131

(This branch also includes some code-style adjustments; tabs, etc. I'll denote the core changes via comments.)

The primary issue is that IE11 does not support `DataTransfer.items`. I researched other libraries, and how they handle this, and they allow any file on the `dragover` event, but do the file-type checking on `drop`. This pull request deals with this problem in the same way.

https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/items#Browser_compatibility
https://caniuse.com/#feat=dragndrop