### PR TITLE
Confirmation dialog adjustments

### DIFF
--- a/src/app/components/confirmation-dialog/confirmation-dialog-demo.component.ts
+++ b/src/app/components/confirmation-dialog/confirmation-dialog-demo.component.ts
@@ -10,28 +10,34 @@ import { SkyConfirmationDialogService } from
 export class SkyConfirmationDialogDemoComponent {
   public action: string;
 
-  constructor(private confirmService: SkyConfirmationDialogService) {}
+  constructor(
+    private confirmService: SkyConfirmationDialogService
+  ) { }
 
   public openConfirmationDialog(type: number) {
-    const config: any = {
+    const instance = this.confirmService.open({
       message: 'Are you really sure you want to do this?',
       type: type
-    };
+    });
 
-    this.confirmService.open(config).closed.subscribe((result: string) => {
-      this.action = 'You clicked \'' + result + '\'';
+    instance.confirmed.subscribe((result: any) => {
+      this.action = `You clicked "${result.action}"`;
     });
   }
 
   public openCustomDialog() {
-    const config: any = {
+    const instance = this.confirmService.open({
       message: 'What option are you going to select?',
       type: 3,
-      buttons: [ { text: '1' }, { text: '2' }, { text: '3', autofocus: true } ]
-    };
+      buttons: [
+        { text: '1' },
+        { text: '2' },
+        { text: '3', autofocus: true }
+      ]
+    });
 
-    this.confirmService.open(config).closed.subscribe((result: string) => {
-      this.action = 'You clicked \'' + result + '\'';
+    instance.confirmed.subscribe((result: any) => {
+      this.action = `You clicked "${result.action}"`;
     });
   }
 }

--- a/src/app/components/confirmation-dialog/index.html
+++ b/src/app/components/confirmation-dialog/index.html
@@ -3,81 +3,82 @@
     The confirmation dialog service launches simple confirmation dialogs to allow users to confirm actions. The <stache-code>SkyConfirmationDialogService</stache-code> provider lauches the confirmation dialog. Within the service, you have options to specify a description, type of dialog, and button text.
   </sky-demo-page-summary>
 
-  <sky-demo-page-properties sectionHeading="Confirmation dialog service methods">
+  <sky-demo-page-properties
+    sectionHeading="Confirmation dialog service methods">
     <sky-demo-page-property
-        propertyName="open(config)"
-    >
-      Opens a confirmation dialog. The <stache-code>config</stache-code> parameter is an object literal to be passed to the component's constructor. This method returns the confirmation dialog instance. 
+      propertyName="open(config)">
+      Opens a confirmation dialog. The <stache-code>config</stache-code> parameter is an object literal to be passed to the component's constructor. This method returns the confirmation dialog instance.
     </sky-demo-page-property>
   </sky-demo-page-properties>
 
-  <sky-demo-page-properties sectionHeading="Confirmation dialog config properties">
+  <sky-demo-page-properties
+    sectionHeading="Confirmation dialog config properties">
     <sky-demo-page-property
-        propertyName="message"
-    >
+      propertyName="message">
       A string property of <stache-code>config</stache-code> that displays the message in the dialog.
     </sky-demo-page-property>
+
     <sky-demo-page-property
-        propertyName="type"
-        isOptional="true"
-    >
+      propertyName="type"
+      isOptional="true">
       An enum of type <stache-code>SkyConfirmationDialogType</stache-code> that specifies the number of buttons and their default text.
     </sky-demo-page-property>
-    <sky-demo-page-property
-        propertyName="buttons"
-        isOptional="true"
-    >
-      An optional array of <stache-code>SkyConfirmationDialogButton</stache-code> that overrides the default button config.
 
+    <sky-demo-page-property
+      propertyName="buttons"
+      isOptional="true">
+      An optional array of <stache-code>SkyConfirmationDialogButtonConfig</stache-code> that overrides the default button config.
     </sky-demo-page-property>
   </sky-demo-page-properties>
 
-  <sky-demo-page-properties sectionHeading="SkyConfirmationDialogType types">
-      <sky-demo-page-property
-          propertyName="OKDialog"
-      >
-        A one-button dialog with 'OK' as the default button text. The integer value equivalent is 1.
+  <sky-demo-page-properties
+    sectionHeading="SkyConfirmationDialogType types">
+    <sky-demo-page-property
+      propertyName="OKDialog">
+      A one-button dialog with 'OK' as the default button text. The integer value equivalent is 1.
+    </sky-demo-page-property>
 
-      </sky-demo-page-property>
-      <sky-demo-page-property
-          propertyName="YesCancelDialog"
-      >
-        A two-button dialog with 'Yes' and 'Cancel' as the default button text. The integer value equivalent is 2.
-        
-      </sky-demo-page-property>
-      <sky-demo-page-property
-          propertyName="YesNoCancelDialog"
-      >
-        A three-button dialog with 'Yes', 'No', and 'Cancel' as the default button text. The integer value equivalent is 3.
-  
-      </sky-demo-page-property>
-    </sky-demo-page-properties>
+    <sky-demo-page-property
+      propertyName="YesCancelDialog">
+      A two-button dialog with 'Yes' and 'Cancel' as the default button text. The integer value equivalent is 2.
+    </sky-demo-page-property>
 
-    <sky-demo-page-properties sectionHeading="SkyConfirmationDialogButton properties">
-        <sky-demo-page-property
-            propertyName="text"
-        >
-          A string property that displays the button text.
-  
-        </sky-demo-page-property>
-        <sky-demo-page-property
-            propertyName="autofocus"
-        >
-          A boolean property that specifies whether to autofocus this button.
-          
-        </sky-demo-page-property>
-      </sky-demo-page-properties>
+    <sky-demo-page-property
+      propertyName="YesNoCancelDialog">
+      A three-button dialog with 'Yes', 'No', and 'Cancel' as the default button text. The integer value equivalent is 3.
+    </sky-demo-page-property>
+  </sky-demo-page-properties>
 
-  <sky-demo-page-properties sectionHeading="Confirmation dialog events">
+  <sky-demo-page-properties
+    sectionHeading="SkyConfirmationDialogButtonConfig properties">
+    <sky-demo-page-property
+      propertyName="text">
+      A string property that displays the button text.
+    </sky-demo-page-property>
+
+    <sky-demo-page-property
+      propertyName="autofocus">
+      A boolean property that specifies whether to autofocus this button.
+    </sky-demo-page-property>
+  </sky-demo-page-properties>
+
+  <sky-demo-page-properties
+    sectionHeading="Confirmation dialog events">
+    <sky-demo-page-property
+      propertyName="confirmed">
+      The event that the confirmation dialog instance emits after a user action is received. An object is returned that provides information about the button clicked.
+    </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="closed">
-      The event that the confirmation dialog instance emits when the dialog is closed. A string is passed back with the text of the button that the user clicked.
+      <em>(deprecated)</em> The event that the confirmation dialog instance emits when the dialog is closed. A string is passed back with the text of the button that the user clicked.
     </sky-demo-page-property>
   </sky-demo-page-properties>
 
   <sky-demo-page-example>
-    <sky-confirmation-dialog-demo></sky-confirmation-dialog-demo>
-    <sky-demo-page-code demoName="Confirmation dialog"></sky-demo-page-code>
+    <sky-confirmation-dialog-demo>
+    </sky-confirmation-dialog-demo>
+    <sky-demo-page-code
+      demoName="Confirmation dialog">
+    </sky-demo-page-code>
   </sky-demo-page-example>
-
 </sky-demo-page>

--- a/src/core.ts
+++ b/src/core.ts
@@ -176,12 +176,7 @@ export {
   SkyColumnSelectorModel
 } from './modules/column-selector';
 
-export {
-  SkyConfirmationDialogService,
-  SkyConfirmationDialogModule,
-  SkyConfirmationDialogType,
-  SkyConfirmationDialogButton
-} from './modules/confirmation-dialog';
+export * from './modules/confirmation-dialog';
 
 export {
   SkyDateFormatter,

--- a/src/modules/confirmation-dialog/confirmation-dialog-button-action.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog-button-action.ts
@@ -1,0 +1,1 @@
+export type SkyConfirmationDialogButtonAction = 'ok' | 'yes' | 'no' | 'cancel';

--- a/src/modules/confirmation-dialog/confirmation-dialog-button-config.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog-button-config.ts
@@ -1,0 +1,4 @@
+export interface SkyConfirmationDialogButtonConfig {
+  text?: string;
+  autofocus?: boolean;
+}

--- a/src/modules/confirmation-dialog/confirmation-dialog-button.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog-button.ts
@@ -1,5 +1,10 @@
+import {
+  SkyConfirmationDialogButtonAction
+} from './confirmation-dialog-button-action';
+
 export class SkyConfirmationDialogButton {
-  public text?: string;
+  public action?: SkyConfirmationDialogButtonAction;
   public autofocus?: boolean;
   public buttonType?: string;
+  public text?: string;
 }

--- a/src/modules/confirmation-dialog/confirmation-dialog-config.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog-config.ts
@@ -1,10 +1,13 @@
-import { SkyConfirmationDialogType } from './confirmation-dialog-type';
+import {
+  SkyConfirmationDialogType
+} from './confirmation-dialog-type';
+
+import {
+  SkyConfirmationDialogButtonConfig
+} from './confirmation-dialog-button-config';
 
 export class SkyConfirmationDialogConfig {
   public message: string;
   public type: SkyConfirmationDialogType;
-  public buttons?: {
-    text?: string;
-    autofocus?: boolean;
-  }[];
+  public buttons?: SkyConfirmationDialogButtonConfig[];
 }

--- a/src/modules/confirmation-dialog/confirmation-dialog-config.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog-config.ts
@@ -1,8 +1,10 @@
 import { SkyConfirmationDialogType } from './confirmation-dialog-type';
-import { SkyConfirmationDialogButton } from './confirmation-dialog-button';
 
 export class SkyConfirmationDialogConfig {
   public message: string;
-  public buttons: Array<SkyConfirmationDialogButton>;
   public type: SkyConfirmationDialogType;
+  public buttons?: {
+    text?: string;
+    autofocus?: boolean;
+  }[];
 }

--- a/src/modules/confirmation-dialog/confirmation-dialog.component.html
+++ b/src/modules/confirmation-dialog/confirmation-dialog.component.html
@@ -12,9 +12,8 @@
             *ngFor="let btn of buttons"
             type="button"
             class="sky-btn sky-confirmation-dialog-btn sky-btn-{{ btn.buttonType }}"
-            (click)="instance.close(btn.text)"
-            [attr.autofocus]="btn.autofocus ? 'autofocus' : null"
-          >
+            (click)="instance.close(btn)"
+            [attr.autofocus]="btn.autofocus ? 'autofocus' : null">
             {{ btn.text }}
           </button>
         </div>

--- a/src/modules/confirmation-dialog/confirmation-dialog.component.spec.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog.component.spec.ts
@@ -19,10 +19,12 @@ describe('Confirmation dialog form component', () => {
   let nativeElement: any;
   let element: any;
 
-  let configDialog = function(type: SkyConfirmationDialogType, buttons:
-    Array<SkyConfirmationDialogButton>) {
-
+  const configDialog = function (
+    type: SkyConfirmationDialogType,
+    buttons: SkyConfirmationDialogButton[]
+  ) {
     let config = new SkyConfirmationDialogConfig();
+
     config = {
       message: 'dialog message test',
       type: type,

--- a/src/modules/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog.component.ts
@@ -31,7 +31,7 @@ export class SkyConfirmationDialogComponent implements OnInit {
     this.overrideButtonConfig();
   }
 
-  private getDefaultButtons(): Array<SkyConfirmationDialogButton> {
+  private getDefaultButtons(): SkyConfirmationDialogButton[] {
     const dialogType = this.context.type;
     let buttons: SkyConfirmationDialogButton[];
 

--- a/src/modules/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit } from '@angular/core';
+
+import { SkyModalInstance } from '../modal';
+import { SkyResources } from '../resources';
+
 import { SkyConfirmationDialogConfig } from './confirmation-dialog-config';
 import { SkyConfirmationDialogType } from './confirmation-dialog-type';
 import { SkyConfirmationDialogButton } from './confirmation-dialog-button';
-import { SkyModalInstance } from '../modal/modal-instance';
-import { SkyResources } from '../resources';
 
 @Component({
   selector: 'sky-confirmation-dialog',
@@ -11,21 +13,14 @@ import { SkyResources } from '../resources';
   styleUrls: ['./confirmation-dialog.component.scss']
 })
 export class SkyConfirmationDialogComponent implements OnInit {
-  public buttons: Array<SkyConfirmationDialogButton>;
+  public buttons: SkyConfirmationDialogButton[];
 
   constructor(
     public context: SkyConfirmationDialogConfig,
-    public instance: SkyModalInstance) {}
+    public instance: SkyModalInstance
+  ) { }
 
   public ngOnInit() {
-    if (!this.context.type) {
-      this.context.type = SkyConfirmationDialogType.YesCancelDialog;
-    }
-
-    if (!this.context.buttons) {
-      this.context.buttons = new Array<SkyConfirmationDialogButton>();
-    }
-
     this.createButtons();
   }
 
@@ -37,41 +32,58 @@ export class SkyConfirmationDialogComponent implements OnInit {
   }
 
   private getDefaultButtons(): Array<SkyConfirmationDialogButton> {
-    switch (this.context.type) {
-      case SkyConfirmationDialogType.OKDialog: return [
-        {
-          text: SkyResources.getString('confirm_dialog_default_ok_text'),
-          autofocus: true,
-          buttonType: 'primary'
-        }
-      ];
-      case SkyConfirmationDialogType.YesNoCancelDialog: return [
-        {
-          text: SkyResources.getString('confirm_dialog_default_yes_text'),
-          autofocus: true,
-          buttonType: 'primary'
-        },
-        {
-          text: SkyResources.getString('confirm_dialog_default_no_text'),
-          buttonType: 'default'
-        },
-        {
-          text: SkyResources.getString('confirm_dialog_default_cancel_text'),
-          buttonType: 'link'
-        }
-      ];
-      default: return [
-        {
-          text: SkyResources.getString('confirm_dialog_default_yes_text'),
-          autofocus: true,
-          buttonType: 'primary'
-        },
-        {
-          text: SkyResources.getString('confirm_dialog_default_cancel_text'),
-          buttonType: 'link'
-        }
-      ];
+    const dialogType = this.context.type;
+    let buttons: SkyConfirmationDialogButton[];
+
+    switch (dialogType) {
+      case SkyConfirmationDialogType.OKDialog:
+        buttons = [
+          {
+            text: SkyResources.getString('confirm_dialog_default_ok_text'),
+            autofocus: true,
+            buttonType: 'primary',
+            action: 'ok'
+          }
+        ];
+        break;
+      case SkyConfirmationDialogType.YesNoCancelDialog:
+        buttons = [
+          {
+            text: SkyResources.getString('confirm_dialog_default_yes_text'),
+            autofocus: true,
+            buttonType: 'primary',
+            action: 'yes'
+          },
+          {
+            text: SkyResources.getString('confirm_dialog_default_no_text'),
+            buttonType: 'default',
+            action: 'no'
+          },
+          {
+            text: SkyResources.getString('confirm_dialog_default_cancel_text'),
+            buttonType: 'link',
+            action: 'cancel'
+          }
+        ];
+        break;
+      default:
+        buttons = [
+          {
+            text: SkyResources.getString('confirm_dialog_default_yes_text'),
+            autofocus: true,
+            buttonType: 'primary',
+            action: 'yes'
+          },
+          {
+            text: SkyResources.getString('confirm_dialog_default_cancel_text'),
+            buttonType: 'link',
+            action: 'cancel'
+          }
+        ];
+        break;
     }
+
+    return buttons;
   }
 
   private overrideButtonConfig() {

--- a/src/modules/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog.component.ts
@@ -87,7 +87,7 @@ export class SkyConfirmationDialogComponent implements OnInit {
   }
 
   private overrideButtonConfig() {
-    const configButtons = this.context.buttons;
+    const configButtons = this.context.buttons || [];
 
     this.buttons.forEach((button: any, i: number) => {
       if (configButtons[i]) {

--- a/src/modules/confirmation-dialog/confirmation-dialog.instance.spec.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog.instance.spec.ts
@@ -20,7 +20,7 @@ describe('Confirmation dialog instance', () => {
       expectedResult = result;
     });
 
-    confirmInstance.modalInstance.close('yes');
+    confirmInstance.modalInstance.close({ text: 'yes' });
 
     expect(expectedResult).toBe('yes');
   });

--- a/src/modules/confirmation-dialog/confirmation-dialog.instance.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog.instance.ts
@@ -1,25 +1,47 @@
 import { Injectable, EventEmitter } from '@angular/core';
+
+import {
+  SkyModalService,
+  SkyModalInstance
+} from '../modal';
+
 import { SkyConfirmationDialogConfig } from './confirmation-dialog-config';
 import { SkyConfirmationDialogComponent } from './confirmation-dialog.component';
-import { SkyModalService } from '../modal/modal.service';
-import { SkyModalInstance } from '../modal/modal-instance';
+import { SkyConfirmationDialogButton } from './confirmation-dialog-button';
 
 @Injectable()
 export class SkyConfirmationDialogInstance {
   public closed = new EventEmitter<string>();
+  public confirmed = new EventEmitter<SkyConfirmationDialogButton>();
   public modalInstance: SkyModalInstance;
 
-  public open(modal: SkyModalService, config: SkyConfirmationDialogConfig):
-    SkyConfirmationDialogInstance {
+  public open(
+    modal: SkyModalService,
+    config: SkyConfirmationDialogConfig
+  ): SkyConfirmationDialogInstance {
 
     const options: any = {
-      providers: [{ provide: SkyConfirmationDialogConfig, useValue: config }]
+      providers: [{
+        provide: SkyConfirmationDialogConfig,
+        useValue: config
+      }]
     };
 
     this.modalInstance = modal.open(SkyConfirmationDialogComponent, options);
 
     this.modalInstance.closed.subscribe((result: any) => {
-      this.closed.emit(result.data);
+      // The modal was closed using the ESC key:
+      if (result.data === undefined) {
+        result.data = {
+          text: '',
+          action: 'cancel'
+        } as SkyConfirmationDialogButton;
+      }
+
+      this.confirmed.emit(result.data);
+
+      // TODO: This emitter is deprecated:
+      this.closed.emit(result.data.text);
     });
 
     return this;

--- a/src/modules/confirmation-dialog/confirmation-dialog.module.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog.module.ts
@@ -2,10 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { SkyModalModule } from '../modal';
+import { SkyResourcesModule } from '../resources';
 
 import { SkyConfirmationDialogService } from './confirmation-dialog.service';
 import { SkyConfirmationDialogComponent } from './confirmation-dialog.component';
-import { SkyResourcesModule } from '../resources';
 
 @NgModule({
   declarations: [

--- a/src/modules/confirmation-dialog/confirmation-dialog.service.ts
+++ b/src/modules/confirmation-dialog/confirmation-dialog.service.ts
@@ -1,14 +1,22 @@
 import { Injectable } from '@angular/core';
+
+import { SkyModalService } from '../modal/modal.service';
+
 import { SkyConfirmationDialogConfig } from './confirmation-dialog-config';
 import { SkyConfirmationDialogInstance } from './confirmation-dialog.instance';
-import { SkyModalService } from '../modal/modal.service';
 
 @Injectable()
 export class SkyConfirmationDialogService {
-  constructor(private modal: SkyModalService) {}
+  constructor(
+    private modal: SkyModalService
+  ) { }
 
   public open(config: SkyConfirmationDialogConfig): SkyConfirmationDialogInstance {
-    let instance = new SkyConfirmationDialogInstance();
+    const instance = new SkyConfirmationDialogInstance();
+
+    if (config.buttons === undefined) {
+      config.buttons = [];
+    }
 
     return instance.open(this.modal, config);
   }

--- a/src/modules/confirmation-dialog/fixtures/mocks.ts
+++ b/src/modules/confirmation-dialog/fixtures/mocks.ts
@@ -1,11 +1,15 @@
 import { EventEmitter } from '@angular/core';
+
 import { SkyModalService } from '../../modal/modal.service';
 import { SkyModalInstance } from '../../modal/modal-instance';
-import { SkyModalConfigurationInterface as IConfig } from '../../modal/modal.interface';
 
 export class SkyModalInstanceMock extends SkyModalInstance {
   public closed = new EventEmitter<any>();
-  public close(result?: any) { this.closed.emit({ data: result }); }
+  public close(result?: any) {
+    this.closed.emit({
+      data: result
+    });
+  }
   public save() {}
 }
 
@@ -23,7 +27,7 @@ export interface OpenParameters {
 export class MockModalService extends SkyModalService {
   public openCalls: OpenParameters[] = [];
 
-  public open(component: any, config?: IConfig): SkyModalInstanceMock {
+  public open(component: any, config?: any): SkyModalInstanceMock {
     this.openCalls.push({component: component, config: config });
 
     return new SkyModalInstanceMock();

--- a/src/modules/confirmation-dialog/index.ts
+++ b/src/modules/confirmation-dialog/index.ts
@@ -1,4 +1,5 @@
 export * from './confirmation-dialog-button-action';
+export * from './confirmation-dialog-button-config';
 export * from './confirmation-dialog-button';
 export * from './confirmation-dialog-config';
 export * from './confirmation-dialog-type';

--- a/src/modules/confirmation-dialog/index.ts
+++ b/src/modules/confirmation-dialog/index.ts
@@ -1,6 +1,8 @@
-export { SkyConfirmationDialogComponent } from './confirmation-dialog.component';
-export { SkyConfirmationDialogButton } from './confirmation-dialog-button';
-export { SkyConfirmationDialogConfig } from './confirmation-dialog-config';
-export { SkyConfirmationDialogService } from './confirmation-dialog.service';
-export { SkyConfirmationDialogModule } from './confirmation-dialog.module';
-export { SkyConfirmationDialogType } from './confirmation-dialog-type';
+export * from './confirmation-dialog-button-action';
+export * from './confirmation-dialog-button';
+export * from './confirmation-dialog-config';
+export * from './confirmation-dialog-type';
+export * from './confirmation-dialog.component';
+export * from './confirmation-dialog.instance';
+export * from './confirmation-dialog.module';
+export * from './confirmation-dialog.service';


### PR DESCRIPTION
**Addresses:**

https://github.com/blackbaud/skyux2/issues/1330
https://github.com/blackbaud/skyux2/issues/1329
https://github.com/blackbaud/skyux2/issues/1328
https://github.com/blackbaud/skyux2/issues/1324
https://github.com/blackbaud/skyux2/issues/1323

- Created a new event emitter named `confirmed` which returns an object representing the button clicked.
- Created a separate config type for the buttons array (so that the `buttonType` property isn't exposed to the consumer)
- Updated docs to "deprecate" the `closed` emitter.
