### PR TITLE
Replace innerText call with textContent

### DIFF
--- a/src/modules/testing/matchers.ts
+++ b/src/modules/testing/matchers.ts
@@ -33,7 +33,7 @@ let skyMatchers: jasmine.CustomMatcherFactories = {
           message: ''
         };
 
-        let actualText = el.innerText;
+        let actualText = el.textContent;
 
         if (trimWhitespace) {
           actualText = actualText.trim();


### PR DESCRIPTION
A bug was encountered when testing a directive within a SkyUX2 SPA where overflow styling was causing certain test to fail. This was determined to be caused by the use of the `innerText` element property. 

The `innerText` property is only text that is actually rendered on the page while `textContent` is the all text, regardless whether it is rendered.

Because the point of unit tests is to test the TypeScript portion of the application and the visual tests determine if the content is correctly rendered, I think this should be pulled to master.