### PR TITLE
Fixed search not working for list view grid demo

### DIFF
--- a/src/demos/list-view-grid/list-view-grid-demo.component.html
+++ b/src/demos/list-view-grid/list-view-grid-demo.component.html
@@ -8,6 +8,7 @@
 
   <sky-list-view-grid fit="scroll" #grid>
     <sky-grid-column
+      field="control"
       [locked]="true"
       [template]="customCellTemplate">
     </sky-grid-column>


### PR DESCRIPTION
The search isn't working for the list view grid demo because the custom dropdown column didn't have a `field` attribute set.