### PR TITLE
[HOLD] WIP: Bumping the version of RxJS for `pipe` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "SKY UX built on Angular 2",
   "author": "Blackbaud, Inc.",
   "homepage": "https://github.com/blackbaud/skyux2",
@@ -101,7 +101,7 @@
     "rollup-plugin-commonjs": "8.0.2",
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-uglify": "1.0.2",
-    "rxjs": "5.4.3",
+    "rxjs": "5.5.6",
     "sass-loader": "6.0.5",
     "selenium-standalone": "6.4.1",
     "source-map-inline-loader": "blackbaud-bobbyearl/source-map-inline-loader",


### PR DESCRIPTION
RxJS [5.5.*](https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#550-beta0-2017-09-22) introduced the concept of [pipes](https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md). It would be handy to be able to take advantage of them.

Note: This relies on https://github.com/blackbaud/skyux-builder/pull/361