### PR TITLE
Fixed dropdown positioning lag; bad unit test

### DIFF
--- a/src/modules/dropdown/dropdown.component.spec.ts
+++ b/src/modules/dropdown/dropdown.component.spec.ts
@@ -1,5 +1,4 @@
 import {
-  async,
   ComponentFixture,
   fakeAsync,
   TestBed,
@@ -23,17 +22,18 @@ describe('Dropdown component', () => {
   let fixture: ComponentFixture<DropdownTestComponent>;
   let component: DropdownTestComponent;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
         SkyDropdownFixturesModule
       ]
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
+    });
     fixture = TestBed.createComponent(DropdownTestComponent);
     component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    fixture.destroy();
   });
 
   function openPopoverWithButtonClick() {

--- a/src/modules/dropdown/dropdown.component.ts
+++ b/src/modules/dropdown/dropdown.component.ts
@@ -193,7 +193,9 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
       case SkyDropdownMessageType.Reposition:
       // Only reposition the dropdown if it is already open.
       if (this.isOpen) {
-        this.popover.reposition();
+        this.windowRef.getWindow().setTimeout(() => {
+          this.popover.reposition();
+        });
       }
       break;
 

--- a/src/modules/popover/popover.component.spec.ts
+++ b/src/modules/popover/popover.component.spec.ts
@@ -325,7 +325,7 @@ describe('SkyPopoverComponent', () => {
   }));
 
   it('should expose a method to return the placement to the preferred placement', fakeAsync(() => {
-    spyOn(mockAdapterService, 'getPopoverPosition').and.returnValue({
+    const spy = spyOn(mockAdapterService, 'getPopoverPosition').and.returnValue({
       top: 0,
       left: 0,
       arrowLeft: 0,
@@ -342,8 +342,7 @@ describe('SkyPopoverComponent', () => {
     expect(component.placement).toEqual('right');
 
     component.reposition();
-    expect(component.placement).toEqual('above');
-    tick();
+    expect(spy.calls.argsFor(1)[1]).toEqual('above');
   }));
 
   it('should hide the popover if its top or bottom boundaries leave its scrollable parent', fakeAsync(() => {

--- a/src/modules/popover/popover.component.ts
+++ b/src/modules/popover/popover.component.ts
@@ -160,13 +160,11 @@ export class SkyPopoverComponent implements OnInit, OnDestroy {
     this.placement = this.preferredPlacement;
     this.changeDetector.markForCheck();
 
-    this.windowRef.getWindow().setTimeout(() => {
-      if (this.adapterService.isPopoverLargerThanParent(this.popoverContainer)) {
-        this.placement = 'fullscreen';
-      }
+    if (this.adapterService.isPopoverLargerThanParent(this.popoverContainer)) {
+      this.placement = 'fullscreen';
+    }
 
-      this.positionPopover();
-    });
+    this.positionPopover();
   }
 
   public close() {

--- a/src/modules/timepicker/timepicker-component.spec.ts
+++ b/src/modules/timepicker/timepicker-component.spec.ts
@@ -129,9 +129,10 @@ describe('Timepicker', () => {
     const closeButton = fixture.nativeElement.querySelector('.sky-timepicker-footer button');
     closeButton.click();
     tick();
+    fixture.detectChanges();
     tick();
-    const dropdown = fixture.nativeElement.querySelector('.sky-popover-container') as HTMLElement;
-    expect(dropdown.classList.contains('sky-popover-hidden')).toEqual(false);
+    const hiddenPopover = fixture.nativeElement.querySelector('.sky-popover-hidden') as HTMLElement;
+    expect(hiddenPopover).not.toBeNull();
   }));
 
   it('should handle input change with a string with the expected timeFormat', fakeAsync(() => {


### PR DESCRIPTION
- The dropdown repositions itself on scroll and resize events. On the master branch, there is a noticeable "lag" when it's rewriting the top and left pixel values. This branch fixes that.
- I also noticed a "bad" unit test for the Timepicker.