### PR TITLE
Fix toasts appearing under modal

### DIFF
--- a/src/modules/toast/toast.component.scss
+++ b/src/modules/toast/toast.component.scss
@@ -10,6 +10,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  z-index: $sky-toast-z-index;
 
   button {
     margin-left: auto;

--- a/src/modules/toast/toaster.component.scss
+++ b/src/modules/toast/toaster.component.scss
@@ -11,4 +11,5 @@
   padding-bottom: $sky-margin-double;
   padding-right: $sky-margin-double;
   padding-top: 50px;
+  z-index: $sky-toaster-z-index;
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -103,6 +103,11 @@ $sky-fluid-grid-columns: 12 !default;
 $sky-flyout-z-index: 1001 !default; // omnibar is 1000, help is 9999:
 // end flyout
 
+// begin toast
+$sky-toaster-z-index: 1051 !default; // modal is 1050:
+$sky-toast-z-index: 1052 !default; // modal is 1050:
+// end toast
+
 // begin grid
 $sky-grid-odd-background-color: $sky-color-gray-01 !default;
 $sky-grid-even-background-color: $sky-color-white !default;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -105,7 +105,7 @@ $sky-flyout-z-index: 1001 !default; // omnibar is 1000, help is 9999:
 
 // begin toast
 $sky-toaster-z-index: 1051 !default; // modal is 1050:
-$sky-toast-z-index: 1052 !default; // modal is 1050:
+$sky-toast-z-index: 1052 !default;
 // end toast
 
 // begin grid


### PR DESCRIPTION
Added z-indexes to toaster and toast so they appear over the modal background and can be closed while the modal is open.

Resolves: #1708 