### PR TITLE
added link to alert demo to illustrate style

### DIFF
--- a/src/demos/alert/alert-demo.component.html
+++ b/src/demos/alert/alert-demo.component.html
@@ -2,7 +2,7 @@
   [alertType]="alertType"
   [closeable]="closeable"
   [closed]="closed">
-  This is a sample alert.
+  This is a sample alert with some link: <a href="http://example.com"> example.com </a>
 </sky-alert>
 <select [(ngModel)]="alertType">
   <option value="info">info</option>


### PR DESCRIPTION
added a link on the alert demo to indicate that they are already styled differently to ensure accessibility. Note a link is already present in the custom component toast demo.

Resolves: #1721 