### PR TITLE
added aria-hidden to the action button icon

### DIFF
--- a/src/modules/action-button/action-button-icon.component.html
+++ b/src/modules/action-button/action-button-icon.component.html
@@ -1,4 +1,6 @@
-<span class="sky-action-button-icon-container">
+<span
+  aria-hidden="true"
+  class="sky-action-button-icon-container">
   <i
     class="fa sky-action-button-icon"
     [ngClass]="['fa-' + iconType, fontSizeClass]">


### PR DESCRIPTION
added aria-hidden to the action button icon so that screen reader users do not receive unintelligible '?' boxes in addition to the button text

Resolves: #1466 