### PR TITLE
changed label property to not default for select type dropdowns

### DIFF
--- a/src/modules/dropdown/dropdown.component.spec.ts
+++ b/src/modules/dropdown/dropdown.component.spec.ts
@@ -260,7 +260,7 @@ describe('Dropdown component', () => {
       expect(buttonElem.getAttribute('title')).toBe('Dropdown title');
     });
 
-    it('should display default label when label not set and buttonType is not select', () => {
+    it('should display default label when label not set and buttonType is not select or tab', () => {
       fixture.componentInstance.buttonType = 'context-menu';
       fixture.detectChanges();
       const buttonElem = getDropdownButtonElement();

--- a/src/modules/dropdown/dropdown.component.spec.ts
+++ b/src/modules/dropdown/dropdown.component.spec.ts
@@ -236,11 +236,20 @@ describe('Dropdown component', () => {
       expect(buttonElem.getAttribute('title')).toBe('Dropdown title');
     });
 
-    it('should display default label when label not set', () => {
+    it('should display default label when label not set and buttonType is not select', () => {
+      fixture.componentInstance.buttonType = 'context-menu';
       fixture.detectChanges();
       const buttonElem = getDropdownButtonElement();
       const label = buttonElem.getAttribute('aria-label');
       expect(label).toBe('Context menu');
+    });
+
+    it('should not display default label when label not set and buttonType is select', () => {
+      fixture.componentInstance.buttonType = 'select';
+      fixture.detectChanges();
+      const buttonElem = getDropdownButtonElement();
+      const label = buttonElem.getAttribute('aria-label');
+      expect(label).toBeFalsy();
     });
 
     it('should display label when label is set', () => {

--- a/src/modules/dropdown/dropdown.component.spec.ts
+++ b/src/modules/dropdown/dropdown.component.spec.ts
@@ -262,12 +262,16 @@ describe('Dropdown component', () => {
       expect(label).toBe('Context menu');
     });
 
-    it('should not display default label when label not set and buttonType is select', () => {
+    it('should not display default label when label not set and buttonType is select or tab', () => {
       fixture.componentInstance.buttonType = 'select';
       fixture.detectChanges();
-      const buttonElem = getDropdownButtonElement();
-      const label = buttonElem.getAttribute('aria-label');
-      expect(label).toBeFalsy();
+      let buttonElem = getDropdownButtonElement();
+      expect(buttonElem.getAttribute('aria-label')).toBeFalsy();
+
+      fixture.componentInstance.buttonType = 'tab';
+      fixture.detectChanges();
+      buttonElem = getDropdownButtonElement();
+      expect(buttonElem.getAttribute('aria-label')).toBeFalsy();
     });
 
     it('should display label when label is set', () => {

--- a/src/modules/dropdown/dropdown.component.ts
+++ b/src/modules/dropdown/dropdown.component.ts
@@ -62,7 +62,7 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
 
   @Input()
   public get label(): string {
-    if (this.buttonType === 'select') {
+    if (this.buttonType === 'select' || this.buttonType === 'tab') {
       return this._label;
     }
     return this._label || SkyResources.getString('context_menu_default_label');

--- a/src/modules/dropdown/dropdown.component.ts
+++ b/src/modules/dropdown/dropdown.component.ts
@@ -61,7 +61,10 @@ export class SkyDropdownComponent implements OnInit, OnDestroy {
   }
 
   @Input()
-  public get label(): string{
+  public get label(): string {
+    if (this.buttonType === 'select') {
+      return this._label;
+    }
     return this._label || SkyResources.getString('context_menu_default_label');
   }
 


### PR DESCRIPTION
Changed dropdown button label to not default when there is button text that can be used (avoid redundant messaging)
Resolves: #1188 