### PR TITLE
Visual tests should fail on protractor 199

### DIFF
--- a/skyux-spa-visual-tests/config/utils/start-visual.js
+++ b/skyux-spa-visual-tests/config/utils/start-visual.js
@@ -77,12 +77,6 @@ function killServers(exitCode) {
     httpServer = null;
   }
 
-  // Catch protractor's "Kitchen Sink" error.
-  if (exitCode === 199) {
-    logger.warn('Supressing protractor\'s "kitchen sink" error 199');
-    exitCode = 0;
-  }
-
   logger.info(`Execution Time: ${(new Date().getTime() - start) / 1000} seconds`);
   logger.info(`Exiting process with ${exitCode}`);
   process.exit(exitCode || 0);


### PR DESCRIPTION
A pull request was merged into master even though it failed during the visual step (the step returned with a zero exit code). This should catch those errors.

See: https://api.travis-ci.org/v3/job/404683473/log.txt
