### PR TITLE
Colorpicker bug fixes

### DIFF
--- a/src/modules/colorpicker/colorpicker-input.directive.ts
+++ b/src/modules/colorpicker/colorpicker-input.directive.ts
@@ -69,7 +69,7 @@ export class SkyColorpickerInputDirective
 
   @Input()
   public set initialColor(value: string) {
-    this._initialColor = value || SKY_COLORPICKER_DEFAULT_COLOR;
+    this._initialColor = value;
   }
 
   public get initialColor(): string {
@@ -88,7 +88,7 @@ export class SkyColorpickerInputDirective
   @Input()
   public alphaChannel = 'hex6';
 
-  private _initialColor = SKY_COLORPICKER_DEFAULT_COLOR;
+  private _initialColor: string;
   private modelValue: SkyColorpickerOutput;
 
   constructor(
@@ -123,16 +123,20 @@ export class SkyColorpickerInputDirective
     const element = this.elementRef.nativeElement;
 
     this.renderer.setElementClass(element, 'sky-form-control', true);
-    this.skyColorpickerInput.initialColor = this.initialColor;
+    this.skyColorpickerInput.initialColor = this.initialColor ? this.initialColor : SKY_COLORPICKER_DEFAULT_COLOR;
+    this.skyColorpickerInput.lastAppliedColor = this.skyColorpickerInput.initialColor;
     this.skyColorpickerInput.returnFormat = this.returnFormat;
 
     this.pickerChangedSubscription =
       this.skyColorpickerInput.selectedColorChanged.subscribe((newColor: SkyColorpickerOutput) => {
-        this.writeValue(newColor);
+        if (newColor) {
+          this.modelValue = this.formatter(newColor);
+          this.writeModelValue(this.modelValue);
+        }
         this._onChange(newColor);
       });
 
-    this.skyColorpickerInput.setColorFromString(this.initialColor);
+    this.skyColorpickerInput.setColorFromString(this.skyColorpickerInput.lastAppliedColor);
 
     /// Set aria-label as default, if not set
     if (!this.elementRef.nativeElement.getAttribute('aria-label')) {
@@ -181,10 +185,16 @@ export class SkyColorpickerInputDirective
     if (value) {
       this.modelValue = this.formatter(value);
       this.writeModelValue(this.modelValue);
+
+      if (!this.initialColor) {
+        this.initialColor = value;
+        this.skyColorpickerInput.initialColor = value;
+        this.skyColorpickerInput.lastAppliedColor = value;
+      }
     }
   }
 
-  public validate(control: AbstractControl): {[key: string]: any} {
+  public validate(control: AbstractControl): { [key: string]: any } {
     let value = control.value;
     if (!value) {
       return;
@@ -200,20 +210,20 @@ export class SkyColorpickerInputDirective
     // tslint:disable-next-line:switch-default
     switch (this.outputFormat) {
       case 'rgba':
-      output = model.rgbaText;
-      break;
+        output = model.rgbaText;
+        break;
 
       case 'hsla':
-      output = model.hslaText;
-      break;
+        output = model.hslaText;
+        break;
 
       case 'cmyk':
-      output = model.cmykText;
-      break;
+        output = model.cmykText;
+        break;
 
       case 'hex':
-      output = model.hex;
-      break;
+        output = model.hex;
+        break;
     }
 
     this.skyColorpickerInput.setColorFromString(output);

--- a/src/modules/colorpicker/colorpicker.component.html
+++ b/src/modules/colorpicker/colorpicker.component.html
@@ -5,7 +5,8 @@
   </ng-content>
   <sky-dropdown
     [label]="'colorpicker_dropdown_button' | skyResources"
-    [messageStream]="dropdownController">
+    [messageStream]="dropdownController"
+    [dismissOnBlur]="false">
     <sky-dropdown-menu>
       <div class="sky-colorpicker-container">
         <div

--- a/src/modules/colorpicker/colorpicker.component.spec.ts
+++ b/src/modules/colorpicker/colorpicker.component.spec.ts
@@ -281,6 +281,26 @@ describe('Colorpicker Component', () => {
     verifyColorpicker(nativeElement, '#2889e5', '40, 137, 229');
   }));
 
+  it('should use the last applied color to revert to on cancel', fakeAsync(() => {
+    spyOn(component.colorpickerComponent.selectedColorChanged, 'emit').and.callThrough();
+    spyOn(component.colorpickerComponent.selectedColorApplied, 'emit').and.callThrough();
+    let cancelButton = nativeElement.querySelector('.sky-btn-colorpicker-close');
+    let applyButton = nativeElement.querySelector('.sky-btn-colorpicker-apply');
+    let buttonEvent = document.createEvent('Event');
+    component.selectedOutputFormat = 'hex';
+    verifyColorpicker(nativeElement, '#2889e5', '40, 137, 229');
+    openColorpicker(nativeElement, fixture);
+    setInputElementValue(nativeElement, 'hex', '#2B7230');
+    buttonEvent.initEvent('click', true, false);
+    applyButton.dispatchEvent(buttonEvent);
+    verifyColorpicker(nativeElement, '#2b7230', '43, 114, 48');
+    openColorpicker(nativeElement, fixture);
+    setInputElementValue(nativeElement, 'hex', '#BFF666');
+    buttonEvent.initEvent('click', true, false);
+    cancelButton.dispatchEvent(buttonEvent);
+    verifyColorpicker(nativeElement, '#2b7230', '43, 114, 48');
+  }));
+
   it('should allow user to click apply the color change.', fakeAsync(() => {
     let button = nativeElement.querySelector('.sky-btn-colorpicker-apply');
     let buttonEvent = document.createEvent('Event');
@@ -291,6 +311,22 @@ describe('Colorpicker Component', () => {
     buttonEvent.initEvent('click', true, false);
     button.dispatchEvent(buttonEvent);
     verifyColorpicker(nativeElement, '#2b7230', '43, 114, 48');
+  }));
+
+  it('should emit a selectedColorChanged and selectedColorApplied event on submit', fakeAsync(() => {
+    spyOn(component.colorpickerComponent.selectedColorChanged, 'emit').and.callThrough();
+    spyOn(component.colorpickerComponent.selectedColorApplied, 'emit').and.callThrough();
+    let button = nativeElement.querySelector('.sky-btn-colorpicker-apply');
+    let buttonEvent = document.createEvent('Event');
+    component.selectedOutputFormat = 'hex';
+    openColorpicker(nativeElement, fixture);
+    setInputElementValue(nativeElement, 'hex', '#2B7230');
+    verifyColorpicker(nativeElement, '#2b7230', '43, 114, 48');
+    buttonEvent.initEvent('click', true, false);
+    button.dispatchEvent(buttonEvent);
+    verifyColorpicker(nativeElement, '#2b7230', '43, 114, 48');
+    expect(component.colorpickerComponent.selectedColorChanged.emit).toHaveBeenCalled();
+    expect(component.colorpickerComponent.selectedColorApplied.emit).toHaveBeenCalled();
   }));
 
   it('should accept mouse down events on hue bar.', fakeAsync(() => {
@@ -490,12 +526,16 @@ describe('Colorpicker Component', () => {
     let spyOnResetColorPicker = spyOn(colorpickerComponent, 'resetPickerColor').and.callThrough();
     fixture.detectChanges();
     tick();
+    openColorpicker(nativeElement, fixture);
+    setPresetColor(nativeElement, fixture, 4);
+    fixture.detectChanges();
+    tick();
     const buttonElem = nativeElement.querySelector('.sky-colorpicker-reset-button') as HTMLElement;
     buttonElem.click();
     tick();
     fixture.detectChanges();
     expect(spyOnResetColorPicker).toHaveBeenCalled();
-    verifyColorpicker(nativeElement, 'rgba(255,255,255,1)', '255, 255, 255');
+    verifyColorpicker(nativeElement, 'rgba(40,137,229,1)', '40, 137, 229');
   }));
 
   it('should accept open colorpicker via messageStream.', fakeAsync(() => {
@@ -512,11 +552,15 @@ describe('Colorpicker Component', () => {
     fixture.detectChanges();
     verifyColorpicker(nativeElement, 'rgba(40,137,229,1)', '40, 137, 229');
     tick();
+    openColorpicker(nativeElement, fixture);
+    setPresetColor(nativeElement, fixture, 4);
+    fixture.detectChanges();
+    tick();
     component.sendMessage(SkyColorpickerMessageType.Reset);
     tick();
     fixture.detectChanges();
     tick();
-    verifyColorpicker(nativeElement, 'rgba(255,255,255,1)', '255, 255, 255');
+    verifyColorpicker(nativeElement, 'rgba(40,137,229,1)', '40, 137, 229');
   }));
 
   it('should toggle reset button via messageStream.', fakeAsync(() => {

--- a/src/modules/colorpicker/index.ts
+++ b/src/modules/colorpicker/index.ts
@@ -3,6 +3,7 @@ export { SkyColorpickerComponent } from './colorpicker.component';
 export { SkyColorpickerModule } from './colorpicker.module';
 export {
   SkyColorpickerOutput,
+  SkyColorpickerResult,
   SkyColorpickerMessage,
   SkyColorpickerMessageType
 } from './types';

--- a/src/modules/colorpicker/types/colorpicker-result.ts
+++ b/src/modules/colorpicker/types/colorpicker-result.ts
@@ -1,0 +1,5 @@
+import { SkyColorpickerOutput } from './colorpicker-output';
+
+export interface SkyColorpickerResult {
+  color: SkyColorpickerOutput;
+}

--- a/src/modules/colorpicker/types/index.ts
+++ b/src/modules/colorpicker/types/index.ts
@@ -7,3 +7,4 @@ export * from './colorpicker-message-type';
 export * from './colorpicker-message';
 export * from './colorpicker-output';
 export * from './colorpicker-rgba';
+export * from './colorpicker-result';


### PR DESCRIPTION
#1872 
#1617

Fixed these things
1. Colorpicker no longer closes if you click off the dropdown which contains the opened picker (Verified with Todd Roberts on the expected behavior here)
2. Clicking "Close" on the picker now reverts the picker back to the color that was previously chosen (or given if initially set via code).
3. The reset button now reverts the picker to the color given via code to be the initial color (or white if none was originally given) - previously this button always changed the color to white.
4. The picker now emits a new `selectedColorApplied` event upon a user clicking the "Apply" button.  The `selectedColorChanged` event will still emit on any change to an open picker as it always has.