### PR TITLE
Tab demo clarity, tabIndex bugfix

### DIFF
--- a/src/demos/tabs/tabs-demo.component.html
+++ b/src/demos/tabs/tabs-demo.component.html
@@ -1,31 +1,95 @@
-<sky-tabset
-  (newTab)="newTabClick()"
-  (openTab)="openTabClick()"
-  [active]="activeTabIndex"
-  (activeChange)="tabChanged($event)">
-  <sky-tab
-    *ngFor="let tab of tabs; let i = index"
-    [tabHeading]="tab.heading"
-    (close)="closeClick(i)">
-    {{tab.content}}
-  </sky-tab>
-  <sky-tab
-    tabHeading="Permanent tab"
-    tabIndex="permanent">
-    This tab cannot be closed.
-  </sky-tab>
-</sky-tabset>
-
 <h3>
-  Tabs example with counter
+  Tabs with a default tab selected
 </h3>
 
 <sky-tabset
-  [active]="0">
+  active="tab-2"
+  (activeChange)="tabChanged($event)">
+
   <sky-tab
-    *ngFor="let tab of tabsWithCounts"
-    [tabHeading]="tab.heading"
-    [tabHeaderCount]="tab.headerCount">
-    {{tab.content}}
+    tabHeading="Tab one"
+    tabIndex="tab-1">
+    Content 1
   </sky-tab>
+  <sky-tab
+    tabHeading="Tab two"
+    tabIndex="tab-2">
+    Content 2: I should be active by default!
+  </sky-tab>
+  <sky-tab
+    tabHeading="Tab three"
+    tabIndex="tab-3">
+    Content 3
+  </sky-tab>
+</sky-tabset>
+
+<br />
+
+<h3>
+  Tabs with header counts
+</h3>
+
+<sky-tabset
+  (activeChange)="tabChanged($event)">
+  <sky-tab
+    tabHeading="Records"
+    tabHeaderCount="10">
+    Placeholder content for records
+  </sky-tab>
+  <sky-tab
+    tabHeading="Gifts"
+    tabHeaderCount="14">
+    Placeholder content for gifts
+  </sky-tab>
+  <sky-tab
+    tabHeading="Users"
+    tabHeaderCount="144">
+    Placeholder content for users
+  </sky-tab>
+</sky-tabset>
+
+<br />
+
+<h3>
+  Dynamic tabs bound to an array
+</h3>
+
+<sky-tabset
+  [active]="activeTabIndex1"
+  (activeChange)="tabChanged($event)">
+  <sky-tab
+    *ngFor="let tab of tabsArrayExample1"
+    [tabHeading]="tab.tabHeading"
+    [tabIndex]="tab.tabIndex">
+    {{tab.tabContent}}
+  </sky-tab>
+</sky-tabset>
+
+<br />
+
+<h3>
+  Tabs with add/close functionality
+</h3>
+
+<sky-tabset
+  (newTab)="addTabClick()"
+  (openTab)="openTabClick()"
+  [active]="activeTabIndex2"
+  (activeChange)="tabChanged($event)">
+  <ng-container
+    *ngFor="let tab of tabsArrayExample2; let i = index">
+    <!-- Closeable tabs -->
+    <sky-tab
+      *ngIf="tab.tabIsCloseable"
+      [tabHeading]="tab.tabHeading"
+      (close)="closeClick(i)">
+      {{tab.tabContent}}
+    </sky-tab>
+    <!-- Non-closeable tabs -->
+    <sky-tab
+      *ngIf="!tab.tabIsCloseable"
+      [tabHeading]="tab.tabHeading">
+      {{tab.tabContent}}
+    </sky-tab>
+  </ng-container>
 </sky-tabset>

--- a/src/demos/tabs/tabs-demo.component.html
+++ b/src/demos/tabs/tabs-demo.component.html
@@ -72,10 +72,10 @@
 </h3>
 
 <sky-tabset
-  (newTab)="addTabClick()"
-  (openTab)="openTabClick()"
   [active]="activeTabIndex2"
-  (activeChange)="tabChanged($event)">
+  (activeChange)="tabChanged($event)"
+  (newTab)="addTabClick()"
+  (openTab)="openTabClick()">
   <ng-container
     *ngFor="let tab of tabsArrayExample2; let i = index">
     <!-- Closeable tabs -->

--- a/src/demos/tabs/tabs-demo.component.ts
+++ b/src/demos/tabs/tabs-demo.component.ts
@@ -5,58 +5,66 @@ import { Component } from '@angular/core';
   templateUrl: './tabs-demo.component.html'
 })
 export class SkyTabsDemoComponent {
-  public tabs: any[];
-  public tabsWithCounts: any[];
-  public activeTabIndex: any = 0;
+  public tabsArrayExample1: any[];
+  public tabsArrayExample2: any[];
+  public activeTabIndex1: any = 'tab-1';
+  public activeTabIndex2: any = 0;
+  private tabCounter: number;
 
   constructor() {
-    this.tabs = [
+    this.tabsArrayExample1 = [
       {
-        heading: 'Tab 1',
-        content: 'Content 1',
-        active: true
+        tabHeading: 'Tab 1',
+        tabContent: 'Content 1',
+        tabIndex: 'tab-1'
       },
       {
-        heading: 'Tab 2',
-        content: 'Content 2'
+        tabHeading: 'Tab 2',
+        tabContent: 'Content 2',
+        tabIndex: 'tab-2'
       },
       {
-        heading: 'Tab 3',
-        content: 'Content 3'
+        tabHeading: 'Tab 3',
+        tabContent: 'Content 3',
+        tabIndex: 'tab-3'
       }
     ];
-
-    this.tabsWithCounts = [
+    this.tabsArrayExample2 = [
       {
-        heading: 'Records',
-        content: 'Placeholder content for records',
-        headerCount: 10,
-        active: true
+        tabHeading: 'Tab 1',
+        tabContent: 'Content 1',
+        tabIsCloseable: true
       },
       {
-        heading: 'Gifts',
-        content: 'Placeholder content for gifts',
-        headerCount: 14
+        tabHeading: 'Tab 2',
+        tabContent: 'Content 2',
+        tabIsCloseable: true
       },
       {
-        heading: 'Users',
-        content: 'Placeholder content for users',
-        headerCount: 144
+        tabHeading: 'Tab 3',
+        tabContent: 'Content 3',
+        tabIsCloseable: true
+      },
+      {
+        tabHeading: 'Tab 4',
+        tabContent: 'This tab cannot be closed',
+        tabIsCloseable: false
       }
     ];
+    this.tabCounter = this.tabsArrayExample2.length;
   }
 
-  public closeClick(tabIndex: number) {
-    this.tabs.splice(tabIndex, 1);
+  public closeClick(arrayIndex: number) {
+    this.tabsArrayExample2.splice(arrayIndex, 1);
   }
 
-  public newTabClick() {
-    let nextTab = this.tabs && this.tabs.length + 1;
+  public addTabClick() {
+    this.tabCounter++;
 
-    this.tabs.push({
-      heading: 'Tab ' + nextTab,
-      content: 'Content ' + nextTab,
-      active: true
+    this.tabsArrayExample2.push({
+      tabHeading: 'Tab ' + this.tabCounter,
+      tabContent: 'Content ' + this.tabCounter,
+      tabIsCloseable: true
     });
   }
 
@@ -65,6 +73,6 @@ export class SkyTabsDemoComponent {
   }
 
   public tabChanged(newIndex: any) {
-    console.log('new active', this.activeTabIndex);
+    console.log('New active tab index: ', newIndex);
   }
 }

--- a/src/modules/tabs/tab.component.ts
+++ b/src/modules/tabs/tab.component.ts
@@ -61,24 +61,27 @@ export class SkyTabComponent implements OnDestroy, OnChanges {
   }
 
   public ngOnChanges(changes: SimpleChanges) {
-    /* istanbul ignore else */
-    /* sanity check */
-    if (changes) {
-      let activeChange = changes['active'];
-      if (activeChange
-        && this.tabIndex !== undefined
-        && activeChange.previousValue !== activeChange.currentValue
-        && this.active) {
-        this.tabsetService.activateTab(this);
-      }
+    if (this.isTabActivated(changes)) {
+      this.tabsetService.activateTab(this);
     }
-
   }
 
   public ngOnDestroy() {
 
     this.tabsetService.destroyTab(this);
 
+  }
+
+  private isTabActivated(changes: SimpleChanges): boolean {
+    /* istanbul ignore else */
+    /* sanity check */
+    if (changes) {
+      let activeChange = changes['active'];
+      return activeChange
+        && this.tabIndex !== undefined
+        && activeChange.previousValue !== activeChange.currentValue
+        && this.active;
+    }
   }
 
 }

--- a/src/modules/tabs/tabset.service.ts
+++ b/src/modules/tabs/tabset.service.ts
@@ -35,7 +35,7 @@ export class SkyTabsetService {
   public addTab(tab: SkyTabComponent) {
 
     this.tabs.take(1).subscribe((currentTabs) => {
-      if (!tab.tabIndex) {
+      if (tab.tabIndex === undefined) {
         tab.tabIndex = 0;
         let lastTabIndex = this.getLastTabIndex(currentTabs);
         if (currentTabs && (lastTabIndex || lastTabIndex === 0)) {


### PR DESCRIPTION
Relates to #1705 

Based on consumer feedback, we have determined the tabs demo could be expanded a bit more to provide better examples of how to utilize the component. @blackbaud-johnly is working on the documentation for this in a separate issue #1868 .

This changes the following:

1. Adds a few more examples to the tab demo to better show how to effectively use tabIndex property and generate tabs bound to arrays.
2. Fixes a bug in tabset.service.ts where any tabIndex deliberately set to 0 was being overwritten.