### PR TITLE
Popover z-index set to 1001

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -91,7 +91,7 @@ $sky-avatar-border-width: 2px !default;
 // end avatar
 
 // begin dropdown
-$sky-dropdown-z-index: 999 !default;
+$sky-dropdown-z-index: 1001 !default; // omnibar is 1000
 // end dropdown
 
 // begin fluid grid


### PR DESCRIPTION
A z-index of 1001 will always make it appear on top of the omnibar (z-index 1000). This is the same approach we take with the flyout.