### PR TITLE
Fixes vertical tab regression

### DIFF
--- a/src/modules/vertical-tabset/vertical-tabset-group.component.html
+++ b/src/modules/vertical-tabset/vertical-tabset-group.component.html
@@ -1,7 +1,7 @@
 <div class="sky-vertical-tabset-group">
   <div
-    class="sky-vertical-tabset-group-header sky-emphasized sky-padding-even-default"
-    [ngClass]="{'sky-vertical-tabset-group-header-sub-open': subMenuOpen()}"
+    class="sky-vertical-tabset-group-header sky-padding-even-default"
+    [ngClass]="{'sky-emphasized': subMenuOpen()}"
     (click)="toggleMenuOpen()"
     (keyup.enter)="toggleMenuOpen()"
     [tabIndex]="-1"

--- a/src/modules/vertical-tabset/vertical-tabset-group.component.html
+++ b/src/modules/vertical-tabset/vertical-tabset-group.component.html
@@ -1,7 +1,7 @@
 <div class="sky-vertical-tabset-group">
   <div
     class="sky-vertical-tabset-group-header sky-padding-even-default"
-    [ngClass]="{'sky-emphasized': subMenuOpen()}"
+    [ngClass]="{'sky-vertical-tabset-group-header-sub-open sky-emphasized': subMenuOpen()}"
     (click)="toggleMenuOpen()"
     (keyup.enter)="toggleMenuOpen()"
     [tabIndex]="-1"

--- a/src/modules/vertical-tabset/vertical-tabset-group.component.scss
+++ b/src/modules/vertical-tabset/vertical-tabset-group.component.scss
@@ -10,8 +10,11 @@
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  font-weight: 400;
-  color: $sky-text-color-deemphasized;
+
+  &:not(.sky-emphasized) {
+    font-weight: 400;
+    color: $sky-text-color-deemphasized;
+  }
 
   &:hover {
     color: $sky-text-color-default;


### PR DESCRIPTION
Resolves #1956

This regression - in part - happened due to the components `sky-vertical-tabset-group-header` class taking precedence over the imported `sky-emphasized` class due to how Angular's shadow DOM works. The component's style is more specific when the shadow DOM portion is added by Angular and thus takes priority. 

I did have to move the emphasized class as we don't want the non-selected group to be emphasized (I based this off the css before the `theme` library was adopted. 

Before the adoption we used a component style that then referenced the `sky-emphasized` import and thus the shadow DOM didn't come in to play; however, based on conversations with Steve I know that he is now preferring that we use the class itself instead of this method. I'm definitely willing to go back to the old way if that seems better to reviewers than the `:not` selector.