### PR TITLE
Fix icon in sky-radio demo

### DIFF
--- a/src/demos/radio/radio-demo.component.html
+++ b/src/demos/radio/radio-demo.component.html
@@ -99,10 +99,10 @@
     >
     </sky-radio>
     <sky-radio
-      icon="striketbrough"
+      icon="strikethrough"
       name="iconradiotest"
       radioType="info"
-      value="striketbrough"
+      value="strikethrough"
       [disabled]="true"
       [(ngModel)]="iconSelectedValue"
     >


### PR DESCRIPTION
Noticed one icon in the docs wasn't showing, here's a quick fix for it.