### PR TITLE
Updated demos for checkbox and radio components to show the label property in use

### DIFF
--- a/src/demos/checkbox/checkbox-demo.component.html
+++ b/src/demos/checkbox/checkbox-demo.component.html
@@ -24,6 +24,7 @@
     [disabled]="item.disabled"
     [icon]="item.icon"
     [checkboxType]="item.checkboxType"
+    [label]="item.label"
     [(ngModel)]="item.checked">
   </sky-checkbox>
 </div>
@@ -37,6 +38,7 @@
   <sky-checkbox
     *ngFor="let item of iconCheckboxGroup"
     [icon]="item.icon"
+    [label]="item.label"
     [(ngModel)]="item.checked">
   </sky-checkbox>
 </div>

--- a/src/demos/radio/radio-demo.component.html
+++ b/src/demos/radio/radio-demo.component.html
@@ -95,6 +95,7 @@
       name="iconradiotest"
       radioType="info"
       value="info"
+      [label]="Info"
       [(ngModel)]="iconSelectedValue"
     >
     </sky-radio>
@@ -104,6 +105,7 @@
       radioType="info"
       value="strikethrough"
       [disabled]="true"
+      [label]="Strikethrough"
       [(ngModel)]="iconSelectedValue"
     >
     </sky-radio>
@@ -112,6 +114,7 @@
       name="iconradiotest"
       radioType="success"
       value="success"
+      [label]="Star"
       [(ngModel)]="iconSelectedValue"
     >
     </sky-radio>
@@ -120,6 +123,7 @@
       name="iconradiotest"
       radioType="warning"
       value="warning"
+      [label]="Warning"
       [(ngModel)]="iconSelectedValue"
     >
     </sky-radio>
@@ -128,6 +132,7 @@
       name="iconradiotest"
       radioType="danger"
       value="danger"
+      [label]="Danger"
       [(ngModel)]="iconSelectedValue"
     >
     </sky-radio>
@@ -156,6 +161,7 @@
       icon="table"
       name="iconradiogrouptest"
       value="table"
+      [label]="Table"
       [(ngModel)]="iconGroupSelectedValue"
     >
     </sky-radio>
@@ -163,6 +169,7 @@
       icon="list"
       name="iconradiogrouptest"
       value="list"
+      [label]="List"
       [(ngModel)]="iconGroupSelectedValue"
     >
     </sky-radio>
@@ -170,6 +177,7 @@
       icon="th-large"
       name="iconradiogrouptest"
       value="cards"
+      [label]="Cards"
       [(ngModel)]="iconGroupSelectedValue"
     >
     </sky-radio>
@@ -177,6 +185,7 @@
       icon="map-marker"
       name="iconradiogrouptest"
       value="map"
+      [label]="Map"
       [(ngModel)]="iconGroupSelectedValue"
     >
     </sky-radio>


### PR DESCRIPTION
@Blackbaud-MattGregg @blackbaud-johnly I have updated both the checkbox and radio component demos to show the use of the `label` property with icon versions of these components.