### PR TITLE
Added not-found component for custom redirecting.

### DIFF
--- a/src/app/not-found.component.html
+++ b/src/app/not-found.component.html
@@ -1,0 +1,9 @@
+
+<div class="app-not-found">
+  <div class="sky-container">
+    <sky-alert>
+      This page has likely moved to <a [href]="redirect">{{ redirect }}</a>.<br />
+      Automatically redirecting you in {{ redirectInSeconds }} seconds.
+    </sky-alert>
+  </div>
+</div>

--- a/src/app/not-found.component.html
+++ b/src/app/not-found.component.html
@@ -2,8 +2,8 @@
 <div class="app-not-found">
   <div class="sky-container">
     <sky-alert>
-      This page has likely moved to <a [href]="redirect">{{ redirect }}</a>.<br />
-      Automatically redirecting you in {{ redirectInSeconds }} seconds.
+      This page moved to <a [href]="redirect">{{ redirect }}</a>.<br />
+      We will automatically redirect you in {{ redirectInSeconds }} seconds.
     </sky-alert>
   </div>
 </div>

--- a/src/app/not-found.component.scss
+++ b/src/app/not-found.component.scss
@@ -1,0 +1,3 @@
+.app-not-found {
+  margin: 40px;
+}

--- a/src/app/not-found.component.ts
+++ b/src/app/not-found.component.ts
@@ -1,0 +1,27 @@
+import {
+  Component
+} from '@angular/core';
+
+import {
+  ActivatedRoute
+} from '@angular/router';
+
+@Component({
+  templateUrl: './not-found.component.html',
+  styleUrls: [ './not-found.component.scss' ]
+})
+export class NotFoundComponent {
+
+  public redirect = 'https://developer.blackbaud.com/skyux/';
+
+  public redirectInSeconds = 5;
+
+  constructor(
+    route: ActivatedRoute
+  ) {
+    this.redirect = this.redirect + route.snapshot.url[0].path;
+    setTimeout(() => {
+      location.href = this.redirect;
+    }, this.redirectInSeconds * 1000);
+  }
+}


### PR DESCRIPTION
From looking at the [GitHub search](https://github.com/search?q=org%3Ablackbaud+%22https%3A%2F%2Fdeveloper.blackbaud.com%2Fskyux2%22&type=Code) there are links to https://developer.blackbaud.com/skyux2.  They are primarily in old documentation, where it wouldn't be feasible to update the URLs.

We currently handle this via a custom CloudFront redirect rule.  In an effort to move from a one-off rule, I realized I could simply add a redirect to this spa (and let the SPA fall through CloudFront to Host).